### PR TITLE
Fix TTL is set 600 (10min) instead to default 10800

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Internet at large!
   | Field | Value
   | ----: | :----
   | Type  | A
-  | TTL   | 5 minutes
+  | TTL   | 600 seconds
   | Name  | dynamic
   | Value | 127.0.0.1
 
@@ -110,7 +110,7 @@ LOG_LEVEL=DEBUG ./gandi_dyndns.py
 The first time your A record is configured, it may take several hours
 for the changes to propogate through the DNS system!
 
-We set the A record's TTL to 5 minutes so that when the address is dynamically
+We set the A record's TTL to 10 minutes so that when the address is dynamically
 updated by the script, that's the (hopefully) longest amount of time that would
 pass before the DNS system caught up with the change. Setting this much lower
 wouldn't be of much use, and could even cause DNS errors (see

--- a/gandi_dyndns.py
+++ b/gandi_dyndns.py
@@ -317,7 +317,8 @@ def update_ip():
       }, {
         'name': new_dynamic_record['name'],
         'type': new_dynamic_record['type'],
-        'value': external_ip
+        'value': external_ip,
+	'ttl': 600
       })
 
       # ensure that we successfully set the new dynamic record


### PR DESCRIPTION
regarding http://doc.rpc.gandi.net/domain/reference.html#ZoneRecord
manual TTL of 300/600 is always updated to 10800 as this is the default value used if no TTL is in use.